### PR TITLE
feat: add stateless MCP v2 Pages endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,39 @@ bun test:compose
 bun test:containers
 ```
 
+## 🤖 MCP v2 endpoints
+
+The Cloudflare Pages deployment includes three independent, stateless MCP v2
+Streamable HTTP endpoints:
+
+- `https://compose.ajnart.dev/api/mcp/v2/tools` - discover tools and retrieve their Compose definitions
+- `https://compose.ajnart.dev/api/mcp/v2/templates` - discover templates and their tools
+- `https://compose.ajnart.dev/api/mcp/v2/compose` - generate `docker-compose.yaml` and `.env` content
+
+Each endpoint is a separate MCP server. They do not keep sessions or rely on
+in-memory state, so they can run on any Cloudflare Pages Function instance.
+POST requests use JSON responses over the MCP Streamable HTTP transport and the
+endpoint supports the standard `POST`, `GET`, and `DELETE` methods.
+
+The endpoints are public by default. Set the optional `MCP_ACCESS_TOKEN`
+Pages secret to require `Authorization: Bearer <token>`:
+
+```bash
+wrangler pages secret put MCP_ACCESS_TOKEN
+```
+
+The frontend remains a static Next.js export. The deploy script compiles the
+Pages Functions into `out/_worker.js` before uploading `out`:
+
+```bash
+bun run deploy
+```
+
+The Docker image in this repository still serves only the static `out`
+directory, so it does not provide the MCP endpoints. GitHub Pages would have
+the same limitation; the MCP runtime requires Cloudflare Pages Functions or a
+separate Worker.
+
 ## 🔄 Template Gallery
 
 DCM includes a Template Gallery that allows you to quickly add predefined stacks of containers based on common use cases:

--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ Streamable HTTP endpoints:
 
 Each endpoint is a separate MCP server. They do not keep sessions or rely on
 in-memory state, so they can run on any Cloudflare Pages Function instance.
-POST requests use JSON responses over the MCP Streamable HTTP transport and the
-endpoint supports the standard `POST`, `GET`, and `DELETE` methods.
+POST requests use JSON responses over the MCP Streamable HTTP transport. Because
+these endpoints are stateless, `GET` and `DELETE` return `405`; clients should
+use `POST` for initialization and tool calls.
 
 The endpoints are public by default. Set the optional `MCP_ACCESS_TOKEN`
 Pages secret to require `Authorization: Bearer <token>`:

--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "my-v0-project",
       "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
         "@hookform/resolvers": "^5.2.2",
+        "@modelcontextprotocol/server": "2.0.0-alpha.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -62,7 +63,7 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
-        "zod": "^3.25.76",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -105,6 +106,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.1", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg=="],
 
@@ -247,6 +250,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0-alpha.2", "", { "dependencies": { "zod": "^4.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA=="],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.5.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw=="],
 
@@ -1114,7 +1119,7 @@
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zustand": ["zustand@4.5.6", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ=="],
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { GradientButton } from "@/components/ui/gradient-button"
 import { Heart } from "lucide-react"
 import { siGithub } from "simple-icons"
 
+/** Render the shared DCM header and its primary discovery actions. */
 export function Header() {
   return (
     <header className="relative z-10 bg-primary/80 bg-stripes py-8 text-primary-foreground shadow-md dark:bg-stripes-dark">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import { ContainerSubmissionForm } from "@/components/container-submission-form"
+import { McpSetupDialog } from "@/components/mcp-setup-dialog"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { GradientButton } from "@/components/ui/gradient-button"
 import { Heart } from "lucide-react"
@@ -8,7 +9,7 @@ export function Header() {
   return (
     <header className="relative z-10 bg-primary/80 bg-stripes py-8 text-primary-foreground shadow-md dark:bg-stripes-dark">
       <div className="container mx-auto px-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <h1 className="mb-2 font-bold text-xl motion-safe:animate-slide-in-left md:text-2xl lg:text-3xl">
               Docker Compose Generator
@@ -17,8 +18,9 @@ export function Header() {
               Select the tools you want to include in your docker-compose.yaml
             </p>
           </div>
-          <div className="flex flex-wrap gap-3">
+          <div className="flex w-full flex-wrap items-center gap-3 lg:w-auto lg:justify-end">
             <ThemeToggle />
+            <McpSetupDialog />
             <ContainerSubmissionForm />
 
             <GradientButton
@@ -31,10 +33,7 @@ export function Header() {
               <span>Support me</span>
             </GradientButton>
 
-            <GradientButton
-              href="https://github.com/ajnart/dcm"
-              external
-            >
+            <GradientButton href="https://github.com/ajnart/dcm" external>
               <svg
                 aria-label="GitHub"
                 role="img"

--- a/components/mcp-setup-dialog.tsx
+++ b/components/mcp-setup-dialog.tsx
@@ -1,0 +1,280 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  AlertCircle,
+  Box,
+  Check,
+  Copy,
+  FileCode2,
+  LayoutTemplate,
+  Plug,
+} from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+
+const DEFAULT_ORIGIN = "https://compose.ajnart.dev"
+
+const MCP_ENDPOINTS = [
+  {
+    key: "dcm-tools",
+    title: "Container tools",
+    path: "/api/mcp/v2/tools",
+    description: "Discover supported containers and inspect their details.",
+    tools: ["list_docker_tools", "get_docker_tool"],
+    icon: Box,
+  },
+  {
+    key: "dcm-templates",
+    title: "Templates",
+    path: "/api/mcp/v2/templates",
+    description: "Browse curated stacks and retrieve complete templates.",
+    tools: ["list_templates", "get_template"],
+    icon: LayoutTemplate,
+  },
+  {
+    key: "dcm-compose",
+    title: "Compose generation",
+    path: "/api/mcp/v2/compose",
+    description: "Generate Docker Compose and .env output from selected tools.",
+    tools: ["generate_compose"],
+    icon: FileCode2,
+  },
+] as const
+
+type CopyState = "idle" | "success" | "error"
+
+function createMcpConfig(origin: string) {
+  const mcpServers = Object.fromEntries(
+    MCP_ENDPOINTS.map((endpoint) => [
+      endpoint.key,
+      { url: `${origin}${endpoint.path}` },
+    ]),
+  )
+
+  return JSON.stringify({ mcpServers }, null, 2)
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copyState, setCopyState] = useState<CopyState>("idle")
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+    }
+  }, [])
+
+  const handleCopy = async () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopyState("success")
+    } catch {
+      setCopyState("error")
+    }
+
+    resetTimer.current = setTimeout(() => setCopyState("idle"), 3000)
+  }
+
+  let buttonLabel = "Copy config"
+  let statusMessage = ""
+  let ButtonIcon = Copy
+
+  if (copyState === "success") {
+    buttonLabel = "Copied"
+    statusMessage = "Configuration copied to your clipboard."
+    ButtonIcon = Check
+  }
+
+  if (copyState === "error") {
+    buttonLabel = "Copy failed"
+    statusMessage =
+      "Could not access the clipboard. Select and copy the JSON manually."
+    ButtonIcon = AlertCircle
+  }
+
+  return (
+    <div className="flex min-h-9 items-center gap-3">
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        className="border border-zinc-700 bg-zinc-100 text-zinc-950 shadow-sm hover:bg-white focus-visible:ring-zinc-300"
+        onClick={handleCopy}
+      >
+        <ButtonIcon aria-hidden="true" />
+        {buttonLabel}
+      </Button>
+      <output aria-live="polite" className="text-muted-foreground text-xs">
+        {statusMessage}
+      </output>
+    </div>
+  )
+}
+
+export function McpSetupDialog() {
+  const [origin, setOrigin] = useState(DEFAULT_ORIGIN)
+
+  useEffect(() => {
+    setOrigin(window.location.origin)
+  }, [])
+
+  const config = createMcpConfig(origin)
+
+  return (
+    <Dialog>
+      <div className="relative inline-flex">
+        <DialogTrigger asChild>
+          <Button
+            size="sm"
+            className="group relative overflow-hidden border border-cyan-100/40 bg-cyan-50/20 px-4 py-2 text-primary-foreground shadow-md transition-all duration-300 hover:scale-105 hover:bg-cyan-50/30 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+          >
+            <Plug aria-hidden="true" />
+            <span className="hidden sm:inline">MCP setup</span>
+            <span className="sm:hidden">MCP</span>
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 bg-gradient-to-r from-cyan-400/20 to-blue-300/20 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+            />
+          </Button>
+        </DialogTrigger>
+        <Badge className="-right-2 -top-2 pointer-events-none absolute h-5 border-cyan-100/50 bg-cyan-100 px-1.5 font-bold text-[10px] text-cyan-950 shadow-md">
+          NEW
+        </Badge>
+      </div>
+
+      <DialogContent className="max-h-[92vh] w-[calc(100vw-1.5rem)] max-w-5xl gap-0 overflow-y-auto p-0 sm:w-full">
+        <DialogHeader className="border-b bg-muted/30 px-5 py-5 pr-14 text-left sm:px-6">
+          <div className="flex items-start gap-3">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+              <Plug className="h-5 w-5 text-primary" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <DialogTitle className="text-xl leading-tight">
+                  Connect DCM to your AI client
+                </DialogTitle>
+                <Badge variant="secondary">MCP v2 · 3 stateless servers</Badge>
+              </div>
+              <DialogDescription className="max-w-2xl leading-relaxed">
+                Discover containers and templates, then generate Compose files
+                without leaving your MCP-compatible client.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="grid lg:grid-cols-[minmax(0,1fr)_19rem]">
+          <section
+            aria-labelledby="mcp-config-heading"
+            className="min-w-0 space-y-4 p-5 sm:p-6"
+          >
+            <div className="space-y-1">
+              <h3 id="mcp-config-heading" className="font-semibold text-sm">
+                Add all three servers
+              </h3>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Paste this JSON into your client&apos;s MCP configuration. The
+                URLs automatically match this DCM deployment.
+              </p>
+            </div>
+
+            <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950 shadow-inner">
+              <div className="flex items-center justify-between border-zinc-800 border-b px-4 py-2.5">
+                <span className="font-mono text-xs text-zinc-400">
+                  mcp.json
+                </span>
+                <Badge className="border-zinc-700 bg-zinc-900 text-zinc-300 hover:bg-zinc-900">
+                  Streamable HTTP
+                </Badge>
+              </div>
+              <textarea
+                aria-label="MCP JSON configuration"
+                className="h-72 w-full resize-none bg-zinc-950 p-4 font-mono text-xs text-zinc-100 leading-6 outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+                readOnly
+                spellCheck={false}
+                value={config}
+              />
+              <div className="border-zinc-800 border-t bg-zinc-900/70 px-4 py-3">
+                <CopyButton value={config} />
+              </div>
+            </div>
+
+            <div className="rounded-md border bg-muted/30 px-4 py-3 text-muted-foreground text-xs leading-relaxed">
+              Each endpoint is independent and stateless. Clients can connect
+              only the capabilities they need, or use the full configuration
+              above.
+            </div>
+          </section>
+
+          <aside
+            aria-label="MCP endpoints and capabilities"
+            className="space-y-4 border-t bg-muted/25 p-5 sm:p-6 lg:border-t-0 lg:border-l"
+          >
+            <div className="space-y-1">
+              <h3 className="font-semibold text-sm">Available endpoints</h3>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Ready as soon as your client connects.
+              </p>
+            </div>
+
+            <ul className="space-y-3">
+              {MCP_ENDPOINTS.map((endpoint) => {
+                const EndpointIcon = endpoint.icon
+
+                return (
+                  <li
+                    key={endpoint.key}
+                    className="rounded-lg border bg-background/80 p-3 shadow-sm"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 ring-1 ring-primary/15">
+                        <EndpointIcon
+                          className="h-4 w-4 text-primary"
+                          aria-hidden="true"
+                        />
+                      </div>
+                      <div className="min-w-0 space-y-1.5">
+                        <p className="font-semibold text-sm leading-none">
+                          {endpoint.title}
+                        </p>
+                        <code className="block break-all text-[11px] text-primary">
+                          {origin}
+                          {endpoint.path}
+                        </code>
+                        <p className="text-muted-foreground text-xs leading-relaxed">
+                          {endpoint.description}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {endpoint.tools.map((tool) => (
+                        <Badge
+                          key={tool}
+                          variant="outline"
+                          className="font-mono font-normal text-[10px]"
+                        >
+                          {tool}
+                        </Badge>
+                      ))}
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          </aside>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/mcp-setup-dialog.tsx
+++ b/components/mcp-setup-dialog.tsx
@@ -52,6 +52,7 @@ const MCP_ENDPOINTS = [
 
 type CopyState = "idle" | "success" | "error"
 
+/** Generate the MCP client configuration for the active deployment origin. */
 function createMcpConfig(origin: string) {
   const mcpServers = Object.fromEntries(
     MCP_ENDPOINTS.map((endpoint) => [
@@ -63,6 +64,7 @@ function createMcpConfig(origin: string) {
   return JSON.stringify({ mcpServers }, null, 2)
 }
 
+/** Render clipboard feedback for the generated MCP client configuration. */
 function CopyButton({ value }: { value: string }) {
   const [copyState, setCopyState] = useState<CopyState>("idle")
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -73,6 +75,7 @@ function CopyButton({ value }: { value: string }) {
     }
   }, [])
 
+  /** Copy the generated configuration and expose the result to assistive tech. */
   const handleCopy = async () => {
     if (resetTimer.current) clearTimeout(resetTimer.current)
 
@@ -122,6 +125,7 @@ function CopyButton({ value }: { value: string }) {
   )
 }
 
+/** Advertise the MCP endpoints and help users configure an AI client. */
 export function McpSetupDialog() {
   const [origin, setOrigin] = useState(DEFAULT_ORIGIN)
 
@@ -208,6 +212,25 @@ export function McpSetupDialog() {
               <div className="border-zinc-800 border-t bg-zinc-900/70 px-4 py-3">
                 <CopyButton value={config} />
               </div>
+            </div>
+
+            <div className="space-y-1.5 rounded-md border border-primary/20 bg-primary/5 px-4 py-3 text-muted-foreground text-xs leading-relaxed">
+              <p className="font-semibold text-foreground">Deployment note</p>
+              <p>
+                These URLs require the Cloudflare Pages Functions deployment.
+                Static Docker and GitHub Pages builds do not serve MCP routes.
+              </p>
+              <p>
+                If{" "}
+                <code className="font-mono text-foreground">
+                  MCP_ACCESS_TOKEN
+                </code>{" "}
+                is enabled, add{" "}
+                <code className="font-mono text-foreground">
+                  Authorization: Bearer &lt;token&gt;
+                </code>{" "}
+                in your client.
+              </p>
             </div>
 
             <div className="rounded-md border bg-muted/30 px-4 py-3 text-muted-foreground text-xs leading-relaxed">

--- a/functions/_shared/mcp-endpoint.ts
+++ b/functions/_shared/mcp-endpoint.ts
@@ -18,6 +18,7 @@ export type McpPagesFunction = (
 
 const MAX_REQUEST_BYTES = 128 * 1024
 
+/** Return the CORS policy shared by every MCP response. */
 function getCorsHeaders(): Record<string, string> {
   return {
     "Access-Control-Allow-Headers":
@@ -29,6 +30,7 @@ function getCorsHeaders(): Record<string, string> {
   }
 }
 
+/** Read at most the configured request limit before handing the body to MCP. */
 async function limitRequestBody(request: Request): Promise<Request | null> {
   const contentLength = request.headers.get("Content-Length")
   if (
@@ -69,6 +71,7 @@ async function limitRequestBody(request: Request): Promise<Request | null> {
   return new Request(request, { body })
 }
 
+/** Add the shared CORS policy without consuming the response body stream. */
 function withCors(response: Response): Response {
   const headers = new Headers(response.headers)
 
@@ -83,6 +86,7 @@ function withCors(response: Response): Response {
   })
 }
 
+/** Return a JSON error response with the shared CORS policy applied. */
 function errorResponse(
   status: number,
   message: string,
@@ -101,6 +105,7 @@ function errorResponse(
   )
 }
 
+/** Check the optional Pages secret before dispatching an MCP request. */
 function isAuthorized(request: Request, env: McpEnvironment): boolean {
   if (!env.MCP_ACCESS_TOKEN) return true
 
@@ -109,6 +114,7 @@ function isAuthorized(request: Request, env: McpEnvironment): boolean {
   )
 }
 
+/** Create a stateless MCP Pages Function around one server factory. */
 export function createMcpEndpoint(
   createServer: () => McpServer,
 ): McpPagesFunction {

--- a/functions/_shared/mcp-endpoint.ts
+++ b/functions/_shared/mcp-endpoint.ts
@@ -1,0 +1,110 @@
+import {
+  type McpServer,
+  WebStandardStreamableHTTPServerTransport,
+} from "@modelcontextprotocol/server"
+
+export interface McpEnvironment {
+  MCP_ACCESS_TOKEN?: string
+}
+
+export interface McpRequestContext {
+  request: Request
+  env: McpEnvironment
+}
+
+export type McpPagesFunction = (
+  context: McpRequestContext,
+) => Response | Promise<Response>
+
+const MAX_REQUEST_BYTES = 128 * 1024
+
+function getCorsHeaders(): Record<string, string> {
+  return {
+    "Access-Control-Allow-Headers":
+      "Accept, Authorization, Content-Type, Mcp-Protocol-Version, Mcp-Session-Id",
+    "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Expose-Headers": "Mcp-Session-Id",
+    "Access-Control-Max-Age": "86400",
+  }
+}
+
+function withCors(response: Response): Response {
+  const headers = new Headers(response.headers)
+
+  for (const [name, value] of Object.entries(getCorsHeaders())) {
+    headers.set(name, value)
+  }
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+}
+
+function errorResponse(
+  status: number,
+  message: string,
+  headers: Record<string, string> = {},
+): Response {
+  return withCors(
+    Response.json(
+      {
+        error: message,
+      },
+      {
+        headers,
+        status,
+      },
+    ),
+  )
+}
+
+function isAuthorized(request: Request, env: McpEnvironment): boolean {
+  if (!env.MCP_ACCESS_TOKEN) return true
+
+  return (
+    request.headers.get("Authorization") === `Bearer ${env.MCP_ACCESS_TOKEN}`
+  )
+}
+
+export function createMcpEndpoint(
+  createServer: () => McpServer,
+): McpPagesFunction {
+  return async ({ request, env }) => {
+    if (request.method === "OPTIONS") {
+      return withCors(new Response(null, { status: 204 }))
+    }
+
+    if (!isAuthorized(request, env)) {
+      return errorResponse(401, "Unauthorized", {
+        "WWW-Authenticate": "Bearer",
+      })
+    }
+
+    const contentLength = request.headers.get("Content-Length")
+    if (
+      contentLength &&
+      Number.isFinite(Number(contentLength)) &&
+      Number(contentLength) > MAX_REQUEST_BYTES
+    ) {
+      return errorResponse(413, "Request body is too large")
+    }
+
+    const server = createServer()
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: undefined,
+    })
+
+    try {
+      await server.connect(transport)
+      const response = await transport.handleRequest(request)
+      return withCors(response)
+    } catch (error) {
+      console.error("MCP request failed", error)
+      return errorResponse(500, "MCP request failed")
+    }
+  }
+}

--- a/functions/_shared/mcp-endpoint.ts
+++ b/functions/_shared/mcp-endpoint.ts
@@ -22,11 +22,51 @@ function getCorsHeaders(): Record<string, string> {
   return {
     "Access-Control-Allow-Headers":
       "Accept, Authorization, Content-Type, Mcp-Protocol-Version, Mcp-Session-Id",
-    "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Expose-Headers": "Mcp-Session-Id",
     "Access-Control-Max-Age": "86400",
   }
+}
+
+async function limitRequestBody(request: Request): Promise<Request | null> {
+  const contentLength = request.headers.get("Content-Length")
+  if (
+    contentLength &&
+    Number.isFinite(Number(contentLength)) &&
+    Number(contentLength) > MAX_REQUEST_BYTES
+  ) {
+    return null
+  }
+
+  if (!request.body) return request
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+
+    totalBytes += value.byteLength
+    if (totalBytes > MAX_REQUEST_BYTES) {
+      await reader.cancel()
+      return null
+    }
+
+    chunks.push(value)
+  }
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new Request(request, { body })
 }
 
 function withCors(response: Response): Response {
@@ -83,24 +123,26 @@ export function createMcpEndpoint(
       })
     }
 
-    const contentLength = request.headers.get("Content-Length")
-    if (
-      contentLength &&
-      Number.isFinite(Number(contentLength)) &&
-      Number(contentLength) > MAX_REQUEST_BYTES
-    ) {
-      return errorResponse(413, "Request body is too large")
+    if (request.method !== "POST") {
+      return errorResponse(405, "Only POST requests are supported", {
+        Allow: "POST, OPTIONS",
+      })
     }
 
-    const server = createServer()
-    const transport = new WebStandardStreamableHTTPServerTransport({
-      enableJsonResponse: true,
-      sessionIdGenerator: undefined,
-    })
-
     try {
+      const boundedRequest = await limitRequestBody(request)
+      if (!boundedRequest) {
+        return errorResponse(413, "Request body is too large")
+      }
+
+      const server = createServer()
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        enableJsonResponse: true,
+        sessionIdGenerator: undefined,
+      })
+
       await server.connect(transport)
-      const response = await transport.handleRequest(request)
+      const response = await transport.handleRequest(boundedRequest)
       return withCors(response)
     } catch (error) {
       console.error("MCP request failed", error)

--- a/functions/_shared/mcp-servers.ts
+++ b/functions/_shared/mcp-servers.ts
@@ -33,6 +33,7 @@ const defaultComposeSettings = {
   umask: "022",
 }
 
+/** Create a named MCP server with the shared DCM v2 version. */
 function createServer(name: string): McpServer {
   return new McpServer({
     name,
@@ -40,6 +41,7 @@ function createServer(name: string): McpServer {
   })
 }
 
+/** Return the public catalog fields for one Docker tool. */
 function summarizeTool(tool: DockerTool) {
   return {
     category: tool.category,
@@ -53,6 +55,7 @@ function summarizeTool(tool: DockerTool) {
   }
 }
 
+/** Create the stateless MCP server that exposes Docker tool discovery. */
 export function createToolsServer(): McpServer {
   const server = createServer("dcm-tools")
 
@@ -126,6 +129,7 @@ export function createToolsServer(): McpServer {
   return server
 }
 
+/** Create the stateless MCP server that exposes template discovery. */
 export function createTemplatesServer(): McpServer {
   const server = createServer("dcm-templates")
 
@@ -204,6 +208,7 @@ export function createTemplatesServer(): McpServer {
   return server
 }
 
+/** Create the stateless MCP server that generates Compose and env content. */
 export function createComposeServer(): McpServer {
   const server = createServer("dcm-compose")
 

--- a/functions/_shared/mcp-servers.ts
+++ b/functions/_shared/mcp-servers.ts
@@ -1,0 +1,264 @@
+import { McpServer } from "@modelcontextprotocol/server"
+import { z } from "zod"
+
+import {
+  generateComposeContent,
+  generateEnvFile,
+} from "../../lib/docker-compose/generators"
+import type { DockerTool } from "../../lib/docker-tools"
+import { getToolsFromTemplate, templates } from "../../lib/templates"
+import { tools } from "../../tools"
+
+const composeSettingsSchema = z.object({
+  configPath: z.string().optional(),
+  containerNamePrefix: z.string().optional(),
+  dataPath: z.string().optional(),
+  networkMode: z.string().optional(),
+  pgid: z.string().optional(),
+  puid: z.string().optional(),
+  restartPolicy: z.string().optional(),
+  timezone: z.string().optional(),
+  umask: z.string().optional(),
+})
+
+const defaultComposeSettings = {
+  configPath: "/opt/appdata/config",
+  containerNamePrefix: "",
+  dataPath: "/opt/appdata/data",
+  networkMode: "bridge",
+  pgid: "1000",
+  puid: "1000",
+  restartPolicy: "unless-stopped",
+  timezone: "UTC",
+  umask: "022",
+}
+
+function createServer(name: string): McpServer {
+  return new McpServer({
+    name,
+    version: "2.0.0",
+  })
+}
+
+function summarizeTool(tool: DockerTool) {
+  return {
+    category: tool.category,
+    description: tool.description,
+    githubUrl: tool.githubUrl,
+    id: tool.id,
+    isUnsupported: tool.isUnsupported,
+    name: tool.name,
+    stars: tool.stars,
+    tags: tool.tags,
+  }
+}
+
+export function createToolsServer(): McpServer {
+  const server = createServer("dcm-tools")
+
+  server.registerTool(
+    "list_docker_tools",
+    {
+      description: "List the Docker tools available in Docker Compose Maker.",
+      inputSchema: z.object({
+        category: z.string().optional(),
+        search: z.string().optional(),
+      }),
+    },
+    async ({ category, search }) => {
+      const normalizedSearch = search?.trim().toLowerCase()
+      const matchingTools = tools.filter((tool) => {
+        if (
+          category &&
+          tool.category.toLowerCase() !== category.toLowerCase()
+        ) {
+          return false
+        }
+
+        if (!normalizedSearch) return true
+
+        return [tool.id, tool.name, tool.description, ...tool.tags]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch)
+      })
+
+      return {
+        content: [
+          {
+            text: JSON.stringify(matchingTools.map(summarizeTool)),
+            type: "text",
+          },
+        ],
+        structuredContent: {
+          tools: matchingTools.map(summarizeTool),
+        },
+      }
+    },
+  )
+
+  server.registerTool(
+    "get_docker_tool",
+    {
+      description:
+        "Get a Docker tool definition, including its Compose content.",
+      inputSchema: z.object({
+        id: z.string().min(1),
+      }),
+    },
+    async ({ id }) => {
+      const tool = tools.find((candidate) => candidate.id === id)
+
+      if (!tool) {
+        return {
+          content: [{ text: `Unknown Docker tool: ${id}`, type: "text" }],
+          isError: true,
+        }
+      }
+
+      return {
+        content: [{ text: JSON.stringify(tool), type: "text" }],
+        structuredContent: { ...tool },
+      }
+    },
+  )
+
+  return server
+}
+
+export function createTemplatesServer(): McpServer {
+  const server = createServer("dcm-templates")
+
+  server.registerTool(
+    "list_templates",
+    {
+      description: "List the predefined Docker Compose templates.",
+      inputSchema: z.object({
+        category: z.string().optional(),
+        search: z.string().optional(),
+      }),
+    },
+    async ({ category, search }) => {
+      const normalizedSearch = search?.trim().toLowerCase()
+      const matchingTemplates = templates.filter((template) => {
+        if (
+          category &&
+          template.category.toLowerCase() !== category.toLowerCase()
+        ) {
+          return false
+        }
+
+        if (!normalizedSearch) return true
+
+        return [template.id, template.name, template.description]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch)
+      })
+
+      return {
+        content: [
+          {
+            text: JSON.stringify(matchingTemplates),
+            type: "text",
+          },
+        ],
+        structuredContent: {
+          templates: matchingTemplates,
+        },
+      }
+    },
+  )
+
+  server.registerTool(
+    "get_template",
+    {
+      description: "Get a predefined template and its Docker tool definitions.",
+      inputSchema: z.object({
+        id: z.string().min(1),
+      }),
+    },
+    async ({ id }) => {
+      const template = templates.find((candidate) => candidate.id === id)
+
+      if (!template) {
+        return {
+          content: [{ text: `Unknown template: ${id}`, type: "text" }],
+          isError: true,
+        }
+      }
+
+      const templateTools = getToolsFromTemplate(template, tools)
+      const result = {
+        ...template,
+        tools: templateTools,
+      }
+
+      return {
+        content: [{ text: JSON.stringify(result), type: "text" }],
+        structuredContent: result,
+      }
+    },
+  )
+
+  return server
+}
+
+export function createComposeServer(): McpServer {
+  const server = createServer("dcm-compose")
+
+  server.registerTool(
+    "generate_compose",
+    {
+      description:
+        "Generate docker-compose.yaml and .env content for selected Docker tool IDs.",
+      inputSchema: z.object({
+        settings: composeSettingsSchema.optional(),
+        showInterpolated: z.boolean().optional(),
+        toolIds: z.array(z.string().min(1)).min(1).max(50),
+      }),
+    },
+    async ({ settings, showInterpolated, toolIds }) => {
+      const selectedTools = toolIds.map((id) =>
+        tools.find((tool) => tool.id === id),
+      )
+      const missingToolIds = toolIds.filter(
+        (id, index) => !selectedTools[index],
+      )
+
+      if (missingToolIds.length > 0) {
+        return {
+          content: [
+            {
+              text: `Unknown Docker tool IDs: ${missingToolIds.join(", ")}`,
+              type: "text",
+            },
+          ],
+          isError: true,
+        }
+      }
+
+      const composeSettings = {
+        ...defaultComposeSettings,
+        ...settings,
+      }
+      const { content, portConflicts } = generateComposeContent(
+        selectedTools as DockerTool[],
+        composeSettings,
+        showInterpolated ?? false,
+      )
+      const result = {
+        compose: content,
+        env: generateEnvFile(selectedTools as DockerTool[], composeSettings),
+        portConflicts,
+      }
+
+      return {
+        content: [{ text: JSON.stringify(result), type: "text" }],
+        structuredContent: result,
+      }
+    },
+  )
+
+  return server
+}

--- a/functions/_shared/mcp-servers.ts
+++ b/functions/_shared/mcp-servers.ts
@@ -219,6 +219,29 @@ export function createComposeServer(): McpServer {
       }),
     },
     async ({ settings, showInterpolated, toolIds }) => {
+      const seenToolIds = new Set<string>()
+      const duplicateToolIds: string[] = []
+      for (const id of toolIds) {
+        if (seenToolIds.has(id)) {
+          duplicateToolIds.push(id)
+          continue
+        }
+
+        seenToolIds.add(id)
+      }
+
+      if (duplicateToolIds.length > 0) {
+        return {
+          content: [
+            {
+              text: `Duplicate Docker tool IDs: ${duplicateToolIds.join(", ")}`,
+              type: "text",
+            },
+          ],
+          isError: true,
+        }
+      }
+
       const selectedTools = toolIds.map((id) =>
         tools.find((tool) => tool.id === id),
       )

--- a/functions/api/mcp/v2/compose.ts
+++ b/functions/api/mcp/v2/compose.ts
@@ -1,0 +1,4 @@
+import { createMcpEndpoint } from "../../../_shared/mcp-endpoint"
+import { createComposeServer } from "../../../_shared/mcp-servers"
+
+export const onRequest = createMcpEndpoint(createComposeServer)

--- a/functions/api/mcp/v2/templates.ts
+++ b/functions/api/mcp/v2/templates.ts
@@ -1,0 +1,4 @@
+import { createMcpEndpoint } from "../../../_shared/mcp-endpoint"
+import { createTemplatesServer } from "../../../_shared/mcp-servers"
+
+export const onRequest = createMcpEndpoint(createTemplatesServer)

--- a/functions/api/mcp/v2/tools.ts
+++ b/functions/api/mcp/v2/tools.ts
@@ -1,0 +1,4 @@
+import { createMcpEndpoint } from "../../../_shared/mcp-endpoint"
+import { createToolsServer } from "../../../_shared/mcp-servers"
+
+export const onRequest = createMcpEndpoint(createToolsServer)

--- a/lib/docker-tools.ts
+++ b/lib/docker-tools.ts
@@ -94,7 +94,7 @@ export function validateComposeContent(content: string): {
   } catch (error) {
     if (error instanceof z.ZodError) {
       result.isValid = false
-      result.errors = error.errors.map((err) => err.message)
+      result.errors = error.issues.map((issue) => issue.message)
       return result
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
     "lint": "biome lint",
     "format": "biome format",
     "ci": "bun test && bun lint && bun format && bun run build",
-    "deploy": "next build && wrangler pages deploy",
+    "deploy": "next build && wrangler pages functions build --outdir=out/_worker.js && wrangler pages deploy out",
     "test:compose": "bun test tests/validate-compose.test.ts",
     "test:containers": "bun test tests/validate-all-containers.test.ts",
     "test:templates": "bun test tests/templates.test.ts",
     "test": "bun test"
   },
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
@@ -76,7 +78,7 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,3 @@
 name = "dcm"
 pages_build_output_dir = "./out"
+compatibility_date = "2025-12-17"


### PR DESCRIPTION
## Summary

- Add three stateless MCP v2 Streamable HTTP endpoints for Cloudflare Pages:
  - `/api/mcp/v2/tools`
  - `/api/mcp/v2/templates`
  - `/api/mcp/v2/compose`
- Expose tool and template discovery plus Compose and `.env` generation through the existing DCM data and generators.
- Add an MCP setup button and responsive light/dark modal to the home header, with one-copy configuration for all three endpoints.
- Compile Pages Functions into `out/_worker.js` as part of `bun run deploy`.
- Add CORS, optional bearer-token authentication, bounded streamed request bodies, duplicate-ID validation, and POST-only stateless transport behavior.
- Document that the static-only Docker image and GitHub Pages cannot execute the MCP runtime.

## Deployment

This preserves the Next.js static export. Cloudflare Pages is the supported runtime:

```bash
bun run deploy
```

To protect the endpoints:

```bash
wrangler pages secret put MCP_ACCESS_TOKEN
```

The implementation uses `@modelcontextprotocol/server@2.0.0-alpha.2`, the v2 TypeScript SDK package, with its Cloudflare JSON schema peer installed explicitly for Wrangler bundling.

## Validation

- `next build` passed; existing build-time GitHub star requests emitted rate-limit warnings but the static export completed.
- `wrangler pages functions build --outdir=out/_worker.js` passed.
- Local `wrangler pages dev out` served the frontend and all three MCP routes.
- Final focused MCP validation passed: initialize on all endpoints, `tools/list`, Compose plus `.env` generation, CORS preflight, POST-only `405`, duplicate-ID rejection, and chunked oversized-body `413`.
- Agent-browser desktop/mobile QA passed for the header button and modal, including endpoint URLs, JSON config, copy feedback, keyboard close/focus, light/dark modes, responsive scrolling, and screenshots.
- Focused Biome check passed.
- Repository-wide TypeScript still reports pre-existing errors in `tests/template-selection.test.ts` and `tests/validate-compose.test.ts`; no new errors were reported in the changed application files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added three MCP v2 HTTP endpoints for browsing Docker tools, exploring templates, and generating Compose configurations.
  - Added filtering, detailed lookups, validation, default settings, and port-conflict reporting.
  - Added an in-app setup dialog with connection instructions, endpoint capabilities, generated configuration, and copy-to-clipboard support.
  - Added optional bearer-token authentication, CORS support, and request-size protection.

- **Documentation**
  - Documented endpoint usage, authentication, deployment, supported methods, and runtime limitations.

- **Bug Fixes**
  - Updated validation error handling for compatibility with the latest validation library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->